### PR TITLE
feat: added set_admin() function

### DIFF
--- a/contract/Database.sol
+++ b/contract/Database.sol
@@ -13,6 +13,8 @@ contract Database{
     mapping( uint256=> Details) public list;
     mapping (string => bool) public added;
     uint256 public count=0;
+    address public admin;
+    bool alreadyset=false;
     constructor()
     {
 
@@ -21,6 +23,26 @@ contract Database{
     {
         require(!added[aadhar],"Details already added");
         _;
+    }
+    modifier onlyOnce()
+    {
+        require(!alreadyset,"Admin is already set");
+        _;
+    }
+    modifier onlyAdmin()
+    {
+        require(msg.sender==admin,"Only admin can call this function");
+        _;
+    }
+    function set_Admin( address _admin) public onlyOnce()
+    {
+        admin=_admin;
+        alreadyset=true;
+    }
+    function changeAdmin(address newadmin) public onlyAdmin()
+    {
+        admin=newadmin;
+
     }
     
     function addPerson(string calldata aadharId,string calldata name, string calldata DOB, string calldata phoneNo ) public Added (aadharId)


### PR DESCRIPTION
## Description

> created a set_admin() function with a modifier which lets it be called only once.
>created a change admin function with a modifier which will only allow current admin to perform the function.

## Semver Changes

- [ ] Patch (bug fix, no new features)
- [x] Minor (new features, no breaking changes)
- [ ] Major (breaking changes)

#9 

> it adds the set admin feature to the contract.

## Checklist

- [x] I have read the [Contributing Guidelines](../Contributor_Guide/Contruting.md).

